### PR TITLE
Doctrine 4 fix

### DIFF
--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -40,7 +40,8 @@ class AdapterTest extends TestCase
             ["p", "bob", "data", "write", "allow"]
         ], $oldRules);
 
-        $stmt = $conn->createQueryBuilder()->from($adapter->policyTableName)->where('p_type = "p" and v1 = "data" and v3 = "allow"')->select("v0", "v1", "v2", "v3")->execute();
+        $query = $conn->createQueryBuilder()->from($adapter->policyTableName)->where('p_type = "p" and v1 = "data" and v3 = "allow"')->select("v0", "v1", "v2", "v3");
+        $stmt = method_exists($query, "executeQuery") ? $query->executeQuery() : $query->execute();
         $result = method_exists($stmt, 'fetchAssociative') ? $stmt->fetchAllAssociative() : $stmt->fetchAll();
 
         $result = array_map([$adapter, "filterRule"], $result);

--- a/tests/PsrLogger.php
+++ b/tests/PsrLogger.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CasbinAdapter\DBAL\Tests;
+
+use Psr\Log\AbstractLogger;
+
+class PsrLogger extends AbstractLogger
+{
+    public function log($level, string|\Stringable $message, array $context = [])
+    {
+        foreach($context as $k => $v) {
+            $context[$k] = is_string($v) ? $v : json_encode($v);
+        }
+        printf(date('Y-m-d H:i:s') . '[SQL]: ' . strtr($message, $context) . PHP_EOL);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,7 +32,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $tableName = $adapter->policyTableName;
         $conn = $adapter->getConnection();
         $queryBuilder = $conn->createQueryBuilder();
-        $queryBuilder->delete($tableName)->where('1 = 1')->execute();
+        $query = $queryBuilder->delete($tableName)->where('1 = 1');
+        method_exists($query, "executeQuery") ? $query->executeQuery() : $query->execute();
 
         $data = [
             ['p_type' => 'p', 'v0' => 'alice', 'v1' => 'data1', 'v2' => 'read'],
@@ -42,7 +43,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
             ['p_type' => 'g', 'v0' => 'alice', 'v1' => 'data2_admin'],
         ];
         foreach ($data as $row) {
-            $queryBuilder->insert($tableName)->values(array_combine(array_keys($row), array_fill(0, count($row), '?')))->setParameters(array_values($row))->execute();
+            $query = $queryBuilder->insert($tableName)->values(array_combine(array_keys($row), array_fill(0, count($row), '?')))->setParameters(array_values($row));
+            method_exists($query, "executeQuery") ? $query->executeQuery() : $query->execute();
         }
     }
 


### PR DESCRIPTION
Fixes adapter not working in Doctrine 4. I only tested this in PHP 8.3 and Doctrine 4 (using in-memory SQLite DB instead of MySQL) so feel free to test on other PHP and Doctrine versions as well.

Fixes #12.